### PR TITLE
Update debian based image, experimental alpine based image, and add example

### DIFF
--- a/rails-base/alpine/Dockerfile
+++ b/rails-base/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.4-alpine
 
 RUN apk add --no-cache --virtual .rundeps \
     git \
@@ -14,14 +14,18 @@ RUN apk add --no-cache --virtual .rundeps \
     yaml-dev \
     nodejs
 
+ONBUILD ARG UID=1000
 ONBUILD ARG APP_HOME=/app
 ONBUILD ARG BUNDLE_OPTIONS='--without development test'
-ONBUILD RUN mkdir -p $APP_HOME
-ONBUILD WORKDIR $APP_HOME
+ONBUILD ARG SKIP_BUNDLE
 
+ONBUILD RUN adduser -D -u $UID app
+ONBUILD RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
+ONBUILD WORKDIR $APP_HOME
 ONBUILD COPY Gemfile $APP_HOME/
 ONBUILD COPY Gemfile.lock $APP_HOME/
 ONBUILD ADD vendor $APP_HOME/vendor
+
 ONBUILD RUN apk add --no-cache --virtual .builddeps \
               autoconf \
               bzip2-dev \
@@ -42,5 +46,5 @@ ONBUILD RUN apk add --no-cache --virtual .builddeps \
               procps \
               readline-dev \
               zlib-dev \
-         && bundle install -j 8 $BUNDLE_OPTIONS \
-         && apk del .builddeps
+         && ( test "$SKIP_BUNDLE" = "yes" \
+            || ( bundle install $BUNDLE_OPTIONS && apk del .builddeps ))

--- a/rails-base/debian/2.3/Dockerfile
+++ b/rails-base/debian/2.3/Dockerfile
@@ -1,0 +1,56 @@
+FROM ruby:2.3.3-slim
+
+RUN apt-get clean && apt-get update \
+   && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      nodejs \
+   && rm -rf /var/lib/apt/lists/* \
+   && ln -s /usr/bin/nodejs /usr/bin/node
+
+ONBUILD ARG UID=1000
+ONBUILD ARG APP_HOME=/app
+ONBUILD ARG BUNDLE_OPTIONS='--without development test'
+ONBUILD ARG SKIP_BUNDLE
+
+ONBUILD RUN useradd --user-group --uid $UID app
+ONBUILD RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
+ONBUILD WORKDIR $APP_HOME
+ONBUILD COPY Gemfile $APP_HOME/
+ONBUILD COPY Gemfile.lock $APP_HOME/
+ONBUILD ADD vendor $APP_HOME/vendor
+
+ONBUILD RUN apt-get clean && apt-get update && \
+            runDeps=' \
+              libmysqlclient18 \
+              libpq5 \
+              libsqlite3-0 \
+              libxslt1.1 \
+              libxml2 \
+            ' && \
+            buildDeps=' \
+              autoconf \
+              automake \
+              g++ \
+              gcc \
+              patch \
+              make \
+              libbz2-dev \
+              libc6-dev \
+              liblzma-dev \
+              libmagickcore-dev \
+              libmagickwand-dev \
+              libreadline-dev \
+              libtool \
+              libxslt-dev \
+              libmysqlclient-dev \
+              libpq-dev \
+              libsqlite3-dev \
+              libxml2-dev \
+            ' && \
+            apt-get install -y --no-install-recommends $buildDeps && \
+            ( test "$SKIP_BUNDLE" = "yes" || \
+              ( bundle install $BUNDLE_OPTIONS && \
+                apt-get purge -y --auto-remove $buildDeps && \
+                apt-get install -y --no-install-recommends $runDeps && \
+                rm -rf /var/lib/apt/lists/* ))

--- a/rails-base/debian/2.4/Dockerfile
+++ b/rails-base/debian/2.4/Dockerfile
@@ -1,6 +1,5 @@
-FROM ruby:2.3.1-slim
+FROM ruby:2.4.0-slim
 
-RUN sed -i "s/httpredir.debian.org/`curl -s -D - http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`/" /etc/apt/sources.list
 RUN apt-get clean && apt-get update \
    && apt-get install -y --no-install-recommends \
       file \
@@ -9,11 +8,13 @@ RUN apt-get clean && apt-get update \
    && rm -rf /var/lib/apt/lists/* \
    && ln -s /usr/bin/nodejs /usr/bin/node
 
+ONBUILD ARG UID=1000
 ONBUILD ARG APP_HOME=/app
 ONBUILD ARG BUNDLE_OPTIONS='--without development test'
 ONBUILD ARG SKIP_BUNDLE
 
-ONBUILD RUN mkdir -p $APP_HOME
+ONBUILD RUN useradd --user-group --uid $UID app
+ONBUILD RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
 ONBUILD WORKDIR $APP_HOME
 ONBUILD COPY Gemfile $APP_HOME/
 ONBUILD COPY Gemfile.lock $APP_HOME/

--- a/rails-base/example/Dockerfile
+++ b/rails-base/example/Dockerfile
@@ -1,0 +1,16 @@
+FROM degica/rails-base:2.4
+
+# You can install additional packages
+RUN apt-get update && apt-get install -y openssh-client --no-install-recommends && rm -rf /var/lib/apt/lists/*
+
+ADD . $APP_HOME
+
+# Unroot container
+# Firstly, added files should be owned by the running user (app)
+RUN chown -R app:app $APP_HOME
+# Change running user to app
+USER app
+
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/rails-base/example/Dockerfile.development
+++ b/rails-base/example/Dockerfile.development
@@ -1,0 +1,6 @@
+FROM degica/rails-base:debian
+
+RUN apt-get install -y openssh-client --no-install-recommends
+
+RUN chown -R app:app $APP_HOME
+USER app

--- a/rails-base/example/docker-compose.yml
+++ b/rails-base/example/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '2.1'
+services:
+  web: &app_base
+    depends_on:
+      - db
+    build:
+      context: .
+      dockerfile: Dockerfile.development
+      args:
+        - UID=${UID-1000} # ${UID} should be set to host's UID
+        - APP_HOME=${PWD}
+        # Option to skip bundle install.
+        # In development, bundle should be done after image creation to store bundled assets to bundle volume
+        - SKIP_BUNDLE=yes 
+    ports:
+     - "3333:3333"
+    command: rails s -p 3333 -b 0.0.0.0
+    stdin_open: true
+    tty: true
+    links:
+     - db
+    volumes:
+      - bundle:/usr/local/bundle
+      - .:${PWD}
+    environment: &env_base
+      RAILS_ENV: development
+      DATABASE_URL: postgres://postgres:@db:5432
+  spring:
+    <<: *app_base
+    ports: []
+    command: spring server
+    volumes:
+      - bundle:/usr/local/bundle
+      - .:${PWD}
+  db:
+    image: postgres:9.5
+    environment:
+      PGDATA: /data
+    volumes:
+      - pgdata:/data
+volumes:
+  pgdata:
+  bundle:


### PR DESCRIPTION
See https://degica.docbase.io/posts/104229 for why these base images benefit.

After merging this, I'll add the following tags to the images

- `rails-base/debian/2.3` -> `2.3`
- `rails-base/debian/2.4` -> `2.4`
- `rails-base/alpine` -> `alpine`

## Changes

- Add `app` user which will eventually becomes a running user of a container
- Add `UID` build argument to add option to change uid of the running user
  - this is useful for development to make host user ID and container user ID same
- Update ruby version from 2.3.1 to 2.3.3
- Add ruby 2.4 debian base image
- Updated alpine based image (still experimental, prior to beta)
  - Mainly I developed this alpine based image for fun so I'm not planning to use this for our production environment but since alpine is getting popular in docker world and is smaller than debian it's worth researching