### PR TITLE
Install node and npm from the official repository

### DIFF
--- a/rails-base/debian/2.3/Dockerfile
+++ b/rails-base/debian/2.3/Dockerfile
@@ -4,9 +4,12 @@ RUN apt-get clean && apt-get update \
    && apt-get install -y --no-install-recommends \
       file \
       git \
-      nodejs \
-   && rm -rf /var/lib/apt/lists/* \
-   && ln -s /usr/bin/nodejs /usr/bin/node
+      curl \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+   && apt-get install nodejs \
+   && rm -rf /var/lib/apt/lists/*
 
 ONBUILD ARG UID=1000
 ONBUILD ARG APP_HOME=/app

--- a/rails-base/debian/2.4/Dockerfile
+++ b/rails-base/debian/2.4/Dockerfile
@@ -4,9 +4,13 @@ RUN apt-get clean && apt-get update \
    && apt-get install -y --no-install-recommends \
       file \
       git \
-      nodejs \
-   && rm -rf /var/lib/apt/lists/* \
-   && ln -s /usr/bin/nodejs /usr/bin/node
+      curl \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+   && apt-get install nodejs \
+   && rm -rf /var/lib/apt/lists/*
+
 
 ONBUILD ARG UID=1000
 ONBUILD ARG APP_HOME=/app


### PR DESCRIPTION
debian jessie's node is quite old (0.10.x) so this PR replaces it with the official package which is currently 6.11.x