### PR TITLE
Add rails-buildpack

### DIFF
--- a/rails-buildpack/2.4/Dockerfile
+++ b/rails-buildpack/2.4/Dockerfile
@@ -57,7 +57,5 @@ RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-ke
     apt-get -y install google-chrome-stable && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem install spring
-
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/rails-buildpack/2.4/Dockerfile
+++ b/rails-buildpack/2.4/Dockerfile
@@ -1,0 +1,63 @@
+FROM ruby:2.4.5-jessie
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      unzip \
+      curl \
+      autoconf \
+      automake \
+      libmysqlclient-dev \
+      mysql-client \
+      g++ \
+      gcc \
+      gnupg \
+      patch \
+      make \
+      libbz2-dev \
+      libc6-dev \
+      liblzma-dev \
+      libmagickcore-dev \
+      libmagickwand-dev \
+      libreadline-dev \
+      libtool \
+      libxslt-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      libcurl3 \
+      qt5-default \
+      libqt5webkit5-dev \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-tools \
+      gstreamer1.0-x \
+      imagemagick \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node JS
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+   && apt-get install -y nodejs \
+   && rm -rf /var/lib/apt/lists/*
+RUN npm install -g yarn
+
+# Chrome Driver
+ENV CHROMEDRIVER_VERSION 2.45
+RUN mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
+    unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    rm /tmp/chromedriver_linux64.zip && \
+    chmod +x /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver && \
+    ln -fs /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver /usr/local/bin/chromedriver
+
+# Google Chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get -y install google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN gem install spring
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8

--- a/rails-buildpack/2.6/Dockerfile
+++ b/rails-buildpack/2.6/Dockerfile
@@ -57,7 +57,5 @@ RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-ke
     apt-get -y install google-chrome-stable && \
     rm -rf /var/lib/apt/lists/*
 
-RUN gem install spring
-
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/rails-buildpack/2.6/Dockerfile
+++ b/rails-buildpack/2.6/Dockerfile
@@ -1,0 +1,63 @@
+FROM ruby:2.6.0
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      unzip \
+      curl \
+      autoconf \
+      automake \
+      default-libmysqlclient-dev \
+      default-mysql-client \
+      g++ \
+      gcc \
+      gnupg \
+      patch \
+      make \
+      libbz2-dev \
+      libc6-dev \
+      liblzma-dev \
+      libmagickcore-dev \
+      libmagickwand-dev \
+      libreadline-dev \
+      libtool \
+      libxslt-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      libcurl3 \
+      qt5-default \
+      libqt5webkit5-dev \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-tools \
+      gstreamer1.0-x \
+      imagemagick \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node JS
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+   && apt-get install -y nodejs \
+   && rm -rf /var/lib/apt/lists/*
+RUN npm install -g yarn
+
+# Chrome Driver
+ENV CHROMEDRIVER_VERSION 2.45
+RUN mkdir -p /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    curl -sS -o /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
+    unzip -qq /tmp/chromedriver_linux64.zip -d /opt/chromedriver-$CHROMEDRIVER_VERSION && \
+    rm /tmp/chromedriver_linux64.zip && \
+    chmod +x /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver && \
+    ln -fs /opt/chromedriver-$CHROMEDRIVER_VERSION/chromedriver /usr/local/bin/chromedriver
+
+# Google Chrome
+RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
+    apt-get -y install google-chrome-stable && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN gem install spring
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8

--- a/rails-buildpack/README.md
+++ b/rails-buildpack/README.md
@@ -1,0 +1,37 @@
+# Rails buildpack
+
+rails-buildpack image includes common dependencies required for a rails application.
+You can use `rails-buildpack` for your CI or builder of a multi-stage build.
+
+## multi-stage example
+
+```
+FROM degica/rails-buildpack:2.6 AS builder
+
+COPY Gemfile $APP_HOME/
+COPY Gemfile.lock $APP_HOME/
+RUN bundle install --without development test
+
+ADD package.json $APP_HOME/
+ADD yarn.lock $APP_HOME/
+RUN yarn
+
+ADD . $APP_HOME
+
+RUN bundle exec rake assets:precompile RAILS_ENV=production
+
+
+FROM ruby:2.6-slim
+
+ENV APP_HOME=/app
+
+RUN useradd --user-group app
+RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
+WORKDIR $APP_HOME
+
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+ADD --chown=app:app . $APP_HOME
+COPY --from=builder --chown=app:app public/assets public/assets
+
+USER app
+```


### PR DESCRIPTION
This image is based on the official ruby:2.4 (and 2.6) image and installs many packages required for rails app CI to run. The idea is to install whatever dependencies we might need to install in the build process. This is basically the rails version of the official `buildpack-deps` image https://hub.docker.com/_/buildpack-deps/

## Why do we need this image

With Travis, (most of) those packages are pre-installed by travis but with GitLab, we need to specify job docker image so we need to have a image that includes all deps otherwise jobs need to install the deps everytime they run.

## buildpack image for multi stage build

Another idea for using the buildpack image is docker's multi-stage build feature. Now that our GitLab runner caches docker layers, we can use this buildpack image for building our production rails app image using docker multi-stage build to speedup build time and make the result image size (much) smaller.

