### PR TITLE
Add git 2.26

### DIFF
--- a/rails-buildpack/2.6.5-stretch/Dockerfile
+++ b/rails-buildpack/2.6.5-stretch/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       automake \
       default-libmysqlclient-dev \
       default-mysql-client \
+      gettext \
       g++ \
       gcc \
       gnupg \
@@ -39,6 +40,12 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
    && apt-get install -y nodejs \
    && rm -rf /var/lib/apt/lists/*
 RUN npm install -g yarn
+
+RUN wget https://github.com/git/git/archive/v2.26.2.tar.gz -O git.tar.gz \
+ && tar xvf git.tar.gz \
+ && cd git-2.26.2 && make prefix=/usr/local -j4 install \
+ && cd .. && rm git.tar.gz && rm -rf git-2.26.2 \
+ git --version
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
This is a small change to the buildpack to update git to 2.26

The reason for this is that github actions seems to require 2.18 to be able to checkout submodules.