### PR TITLE
Add the Ruby 2.7.3 + Node.js LTS (14.16.1) buildpack

### DIFF
--- a/rails-buildpack/2.7.3/Dockerfile
+++ b/rails-buildpack/2.7.3/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Node JS
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
    && apt-get install -y nodejs \
    && rm -rf /var/lib/apt/lists/*
 RUN npm install -g yarn

--- a/rails-buildpack/2.7.3/Dockerfile
+++ b/rails-buildpack/2.7.3/Dockerfile
@@ -40,9 +40,5 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
    && rm -rf /var/lib/apt/lists/*
 RUN npm install -g yarn
 
-# Install old openssl (we need to contact some old bank services with bad security...)
-RUN wget 'https://security.debian.org/debian-security/pool/updates/main/o/openssl/openssl_1.1.0l-1~deb9u3_amd64.deb'
-RUN dpkg --install 'openssl_1.1.0l-1~deb9u3_amd64.deb'
-
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
## Why Node.js LTS (14.16.1)

We are still using Node.js v10 in our build pipelines, but it has come to EOL. Also, referencing `lts` in https://deb.nodesource.com/setup_lts.x keeps us using the latest stable without manual upgrades in the future.

![image](https://user-images.githubusercontent.com/13315/117773856-c9b50900-b273-11eb-9b28-451e210d7c0e.png)

## Why Renaming `rails-buildpack/2.7.3-old-openssl/Dockerfile` to `rails-buildpack/2.7.3/Dockerfile`

Old openssl inside the buildpack turned out to be unnecessary, and we also wanted to take this opportunity to upgrade our minor Ruby version.

## How to test

1. `docker build rails-buildpack/2.7.3 -t 2.7.3-and-nodejs`
2. `docker run --rm -it 2.7.3-and-nodejs bash`
3. `ruby --version` and confirm that it is `ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [x86_64-linux]`
4. `node --version` and confirm that it is `v14.16.1`
5. `yarn --version` and confirm that it is `1.22.10`