### PR TITLE
Add ruby 2.7.7, 3.21 and update github workflow

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -13,7 +13,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: prepare
       run: |-

--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -22,7 +22,7 @@ jobs:
         pip3 install awscli
     - name: workaround git security
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup
       run: git submodule update --init
     - name: build_and_push

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -9,8 +9,10 @@ jobs:
           - '2.7'
           - '2.7.3'
           - '2.7.5'
+          - '2.7.7'
           - '3.0'
           - '3.1'
+          - '3.2.1'
     container:
       image: docker:git
       env:
@@ -19,7 +21,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: prepare
       run: |-

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -30,7 +30,7 @@ jobs:
         pip3 install awscli
     - name: workaround git security
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: setup
       run: git submodule update --init
     - name: build_and_push

--- a/rails-buildpack/2.7.7/Dockerfile
+++ b/rails-buildpack/2.7.7/Dockerfile
@@ -1,0 +1,45 @@
+FROM ruby:2.7.7
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      unzip \
+      curl \
+      autoconf \
+      automake \
+      default-libmysqlclient-dev \
+      default-mysql-client \
+      g++ \
+      gcc \
+      gnupg \
+      patch \
+      make \
+      libbz2-dev \
+      libc6-dev \
+      liblzma-dev \
+      libmagickcore-dev \
+      libmagickwand-dev \
+      libreadline-dev \
+      libtool \
+      libxslt-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+      libqt5webkit5-dev \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-tools \
+      gstreamer1.0-x \
+      imagemagick \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node JS 16.x
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
+   && apt-get install -y nodejs \
+   && rm -rf /var/lib/apt/lists/*
+RUN npm install -g yarn
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+

--- a/rails-buildpack/3.2.1/Dockerfile
+++ b/rails-buildpack/3.2.1/Dockerfile
@@ -1,0 +1,44 @@
+FROM ruby:3.2.1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      unzip \
+      curl \
+      autoconf \
+      automake \
+      default-libmysqlclient-dev \
+      default-mysql-client \
+      g++ \
+      gcc \
+      gnupg \
+      patch \
+      make \
+      libbz2-dev \
+      libc6-dev \
+      liblzma-dev \
+      libmagickcore-dev \
+      libmagickwand-dev \
+      libreadline-dev \
+      libtool \
+      libxslt-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+      libqt5webkit5-dev \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-tools \
+      gstreamer1.0-x \
+      imagemagick \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node JS
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
+   && apt-get install -y nodejs \
+   && rm -rf /var/lib/apt/lists/*
+RUN npm install -g yarn
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Adds latest ruby images to build from. This will be first used for updating https://github.com/degica/barcelona.
Updates github workflow steps to resolve github actions deprecation warnings, [such as shown from this branch build from another repo](https://github.com/degica/barcelona/actions/runs/4142080001). 
Relevant deprecation messages from the build:
`The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002`
`Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`