### PR TITLE
Add job to clone images to our repo

### DIFF
--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -8,6 +8,8 @@ jobs:
             tag: "4.7.1"
           - image: "selenium/standalone-chrome-debug"
             tag: "3.141.59"
+          - image: "degicigel/echo"
+            tag: "1.0"
     container:
       image: docker:git
       env:

--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -1,0 +1,49 @@
+name: clone-images
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - image: "selenium/standalone-chrome"
+            tag: "4.7.1"
+          - image: "selenium/standalone-chrome-debug"
+            tag: "3.141.59"
+    container:
+      image: docker:git
+      env:
+        ECR_DOCKER_REPOSITORY: public.ecr.aws/degica
+        DOCKER_BUILDKIT: '1'
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: prepare
+      run: |-
+        apk add --no-cache python3 py3-pip
+        pip3 install --upgrade pip
+        pip3 install awscli
+    - name: workaround git security
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - uses: actions/checkout@v3
+    - name: setup
+      run: git submodule update --init
+    - name: pull_and_push
+      run: |-
+        DOCKERHUB_IMAGE="${{ matrix.image }}"
+        ORIGINAL_TAG="${{ matrix.tag }}"
+        NEW_IMAGE=`echo "${{ matrix.image }}" | sed 's/\//-/'`
+        if [[ ${GITHUB_REF##*/} == 'master' ]]; then
+            NEW_TAG=$ORIGINAL_TAG
+        else
+            NEW_TAG=test-${GITHUB_REF##*/}-$ORIGINAL_TAG # branch name for dev usecases
+        fi
+        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/degica
+        docker pull $DOCKERHUB_IMAGE:$ORIGINAL_TAG
+        docker tag $DOCKERHUB_IMAGE:$ORIGINAL_TAG $ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG
+        docker push $ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG
+        echo "$ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG pushed"
+'on':
+  push:
+    branches:
+    - '*'


### PR DESCRIPTION
This is to help with the current work on using [self-hosted github runners.](https://github.com/degica/hats/pull/17328)

This change clones selenium chrome images so we can use in our github runners without hitting [pull limits](https://docs.docker.com/docker-hub/download-rate-limit/#:~:text=Docker%20Hub%20limits%20the%20number,pulls%20per%206%20hour%20period.).

After creating the public repositories in our AWS ECR, I confirmed we can pull the images build for the PR branch without logging in to docker or aws.

```
➜  degica docker pull public.ecr.aws/degica/selenium-standalone-chrome:test-clone-remote-chrome-4.7.1
test-clone-remote-chrome-4.7.1: Pulling from degica/selenium-standalone-chrome
Digest: sha256:32c0133aab5ce9292cecdce558cf21e748a40ece09685082dc41f696cdd14ece
Status: Image is up to date for public.ecr.aws/degica/selenium-standalone-chrome:test-clone-remote-chrome-4.7.1
public.ecr.aws/degica/selenium-standalone-chrome:test-clone-remote-chrome-4.7.1
➜  degica docker pull public.ecr.aws/degica/selenium-standalone-chrome-debug:test-clone-remote-chrome-3.141.59
test-clone-remote-chrome-3.141.59: Pulling from degica/selenium-standalone-chrome-debug
Digest: sha256:0c59037d0a095d7edb7b956e95a24573a6a441654a1acd2f7bebad048ef16e65
Status: Downloaded newer image for public.ecr.aws/degica/selenium-standalone-chrome-debug:test-clone-remote-chrome-3.141.59
public.ecr.aws/degica/selenium-standalone-chrome-debug:test-clone-remote-chrome-3.141.59
```

After this is merged, we will be able to use the images `public.ecr.aws/degica/selenium-standalone-chrome:4.7.1` and `public.ecr.aws/degica/selenium-standalone-chrome-debug:3.141.59` anywhere.

Edit: added degicigel/echo repo as well.