### PR TITLE
Build a Ruby 3.2.3/bookworm image

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -14,6 +14,9 @@ jobs:
           - ruby: '3.2.2'
             folder: '3.1.x' # slim bullseye
             tag: '3.2.2-slim@sha256:81743b016046dd7e6fe55b3b408ac37735786c9dff409ca2191daffa0a66fa7e'
+          - ruby: '3.2.3'
+            folder: '3.1.x' # slim bookworm
+            tag: '3.2.3-slim@sha256:7bd0053d5820b233c060775c8fe21d25a9f3ee1ae4fb04bc8fe7887f9c44a2f3'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -30,8 +30,8 @@ jobs:
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip
-        pip3 install --upgrade pip
-        pip3 install awscli
+        pip3 install --break-system-packages --upgrade pip
+        pip3 install --break-system-packages awscli
     - name: workaround git security
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v3

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -33,8 +33,8 @@ jobs:
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip
-        pip3 install --upgrade pip
-        pip3 install awscli
+        pip3 install --break-system-packages --upgrade pip
+        pip3 install --break-system-packages awscli
     - name: workaround git security
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v3

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -14,6 +14,9 @@ jobs:
           - ruby: '3.2.2'
             folder: '3.1.x' # bullseye
             tag: '3.2.2@sha256:139ee8e0f51fdd5d4b291d0755287e4ef3b9e58a0a78cb054e9a9c2a68a1daa6'
+          - ruby: '3.2.3'
+            folder: '3.1.x' # bookworm
+            tag: '3.2.3@sha256:5590025acebb13cacd5a5a4e5b0733c18d841318b8b788996bb88ce1fc64c565'
           - ruby: '3.3.0-preview1'
             folder: '3.1.x' # bookworm
             tag: '3.3.0-preview1@sha256:4eb0a0d89cac283399a31ab7c690e91e39de9eb836452ef48bc6f9b30f61854d'

--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -23,8 +23,8 @@ jobs:
     - name: prepare
       run: |-
         apk add --no-cache python3 py3-pip
-        pip3 install --upgrade pip
-        pip3 install awscli
+        pip3 install --break-system-packages --upgrade pip
+        pip3 install --break-system-packages awscli
     - name: workaround git security
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - uses: actions/checkout@v3

--- a/rails-buildpack/README.md
+++ b/rails-buildpack/README.md
@@ -17,6 +17,7 @@ public.ecr.aws/degica/rails-buildpack:3.1
 public.ecr.aws/degica/rails-buildpack:3.1.4
 public.ecr.aws/degica/rails-buildpack:3.2.1
 public.ecr.aws/degica/rails-buildpack:3.2.2
+public.ecr.aws/degica/rails-buildpack:3.2.3
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
The base images in question are
- https://hub.docker.com/layers/library/ruby/3.2.3-bookworm/images/sha256-5590025acebb13cacd5a5a4e5b0733c18d841318b8b788996bb88ce1fc64c565
- https://hub.docker.com/layers/library/ruby/3.2.3-slim-bookworm/images/sha256-7bd0053d5820b233c060775c8fe21d25a9f3ee1ae4fb04bc8fe7887f9c44a2f3

This should get us onto OpenSSL 3, which is the point of this, as well as pick up a slightly newer Ruby version.