### PR TITLE
Add builds for Ruby 3.2.4 for upgrade due to CVE

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -17,6 +17,9 @@ jobs:
           - ruby: '3.2.3'
             folder: '3.1.x' # slim bookworm
             tag: '3.2.3-slim@sha256:7bd0053d5820b233c060775c8fe21d25a9f3ee1ae4fb04bc8fe7887f9c44a2f3'
+          - ruby: '3.2.4'
+            folder: '3.1.x' # slim bookworm for linux/amd64
+            tag: '3.2.4-slim@sha256:3752526bb16284b5c8d5e45f2f83bae175e92cace720859d9e04700530392aa2'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -17,6 +17,9 @@ jobs:
           - ruby: '3.2.3'
             folder: '3.1.x' # bookworm
             tag: '3.2.3@sha256:5590025acebb13cacd5a5a4e5b0733c18d841318b8b788996bb88ce1fc64c565'
+          - ruby: '3.2.4'
+            folder: '3.1.x' # bookworm for linux/amd64
+            tag: '3.2.4@sha256:cf386d39f6a0fd0431a02bd1bb4acfa90673f763137ecb829875f9a3d9c26c5a'
           - ruby: '3.3.0-preview1'
             folder: '3.1.x' # bookworm
             tag: '3.3.0-preview1@sha256:4eb0a0d89cac283399a31ab7c690e91e39de9eb836452ef48bc6f9b30f61854d'

--- a/rails-buildpack/README.md
+++ b/rails-buildpack/README.md
@@ -18,6 +18,7 @@ public.ecr.aws/degica/rails-buildpack:3.1.4
 public.ecr.aws/degica/rails-buildpack:3.2.1
 public.ecr.aws/degica/rails-buildpack:3.2.2
 public.ecr.aws/degica/rails-buildpack:3.2.3
+public.ecr.aws/degica/rails-buildpack:3.2.4
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
Add build packs for Ruby 3.2.4 as we want to upgrade due to a [CVE](https://www.ruby-lang.org/en/news/2024/04/23/arbitrary-memory-address-read-regexp-cve-2024-27282/)
This is required for HATS's [Dockerfile](https://github.com/degica/hats/blob/2a17ad9a7a5d8b828845888b28198e78c481f00a/Dockerfile).

I'm just following the convention to add [slim-bookworm image](https://hub.docker.com/layers/library/ruby/3.2.4-slim-bookworm/images/sha256-715c2a0834b8f1b655711c236d5b43d0a1d686ad688949cc4b211cf03b356346?context=explore) for `rails-base` build, and [bookworm image](https://hub.docker.com/layers/library/ruby/3.2.4-bookworm/images/sha256-ccf4f2534900b037a130f079eed00bd6b55f2d5dc0dbf56999de42deb4168e09?context=explore) for Ruby `build-pack` here.
