### PR TITLE
add new ruby versions

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -5,21 +5,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.1.4'
-            folder: '3.1.x' # slim buster
-            tag: '3.1.4-slim@sha256:84ad66a846887df972a2143b8b8e8f737404fd7ad2373b5bb284ceae788f27d9'
-          - ruby: '3.2.1'
-            folder: '3.1.x' # slim buster
-            tag: '3.2.1-slim@sha256:287d618c44bc8d1fbf9b622021bc2680bf6610defa6dd709911dbcb764d9aefc'
-          - ruby: '3.2.2'
-            folder: '3.1.x' # slim bullseye
-            tag: '3.2.2-slim@sha256:81743b016046dd7e6fe55b3b408ac37735786c9dff409ca2191daffa0a66fa7e'
-          - ruby: '3.2.3'
-            folder: '3.1.x' # slim bookworm
-            tag: '3.2.3-slim@sha256:7bd0053d5820b233c060775c8fe21d25a9f3ee1ae4fb04bc8fe7887f9c44a2f3'
           - ruby: '3.2.4'
             folder: '3.1.x' # slim bookworm for linux/amd64
             tag: '3.2.4-slim@sha256:3752526bb16284b5c8d5e45f2f83bae175e92cace720859d9e04700530392aa2'
+          - ruby: '3.3.1'
+            folder: '3.1.x' # slim bookworm for linux/amd64
+            tag: '3.3.1-slim-bookworm@sha256:25ee093f9d3405b4eb6c94b760160293314355c5255ef7974027d1d3d5a33e5f'
+          - ruby: '3.4.0'
+            folder: '3.1.x' # slim bookworm for linux/amd64
+            tag: '3.4.0-preview1-slim-bookworm@sha256:sha256:9a577e3528a9d13c6ad5ee9838409f64ad6ad1d9d98d54241e6ec85e38da5d34'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -13,7 +13,7 @@ jobs:
             tag: '3.3.1-slim-bookworm@sha256:25ee093f9d3405b4eb6c94b760160293314355c5255ef7974027d1d3d5a33e5f'
           - ruby: '3.4.0'
             folder: '3.1.x' # slim bookworm for linux/amd64
-            tag: '3.4.0-preview1-slim-bookworm@sha256:sha256:9a577e3528a9d13c6ad5ee9838409f64ad6ad1d9d98d54241e6ec85e38da5d34'
+            tag: '3.4.0-preview1-slim-bookworm@sha256:9a577e3528a9d13c6ad5ee9838409f64ad6ad1d9d98d54241e6ec85e38da5d34'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -10,7 +10,7 @@ jobs:
             tag: '3.2.4@sha256:cf386d39f6a0fd0431a02bd1bb4acfa90673f763137ecb829875f9a3d9c26c5a'
           - ruby: '3.3.0'
             folder: '3.1.x' # bookworm
-            tag: '3.3.0-bookworm@sha256:sha256:8eb6fb9ea8d522506913b420fbaecace30c15f545fb86a8cf7406179e7efa3fd'
+            tag: '3.3.0-bookworm@sha256:8eb6fb9ea8d522506913b420fbaecace30c15f545fb86a8cf7406179e7efa3fd'
           - ruby: '3.3.1'
             folder: '3.1.x' # bookworm for linux/amd64
             tag: '3.3.1-bookworm@sha256:797d68561a91415e05fd95178f467d86d77bce2d4f17f32683241a687cbd1705'

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -5,24 +5,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.1.4'
-            folder: '3.1.x' # buster
-            tag: '3.1.4@sha256:18d450c9a5c573b2eeedc04cccf2d69a778b12d7e5f0b9caedf8b88abd7701eb'
-          - ruby: '3.2.1'
-            folder: '3.1.x' # buster
-            tag: '3.2.1@sha256:96a985d0ef955b77f3ecff795a7294629e2b8e0c12644c5b73ed817845f11919'
-          - ruby: '3.2.2'
-            folder: '3.1.x' # bullseye
-            tag: '3.2.2@sha256:139ee8e0f51fdd5d4b291d0755287e4ef3b9e58a0a78cb054e9a9c2a68a1daa6'
-          - ruby: '3.2.3'
-            folder: '3.1.x' # bookworm
-            tag: '3.2.3@sha256:5590025acebb13cacd5a5a4e5b0733c18d841318b8b788996bb88ce1fc64c565'
           - ruby: '3.2.4'
             folder: '3.1.x' # bookworm for linux/amd64
             tag: '3.2.4@sha256:cf386d39f6a0fd0431a02bd1bb4acfa90673f763137ecb829875f9a3d9c26c5a'
-          - ruby: '3.3.0-preview1'
+          - ruby: '3.3.0'
             folder: '3.1.x' # bookworm
-            tag: '3.3.0-preview1@sha256:4eb0a0d89cac283399a31ab7c690e91e39de9eb836452ef48bc6f9b30f61854d'
+            tag: '3.3.0-bookworm@sha256:sha256:8eb6fb9ea8d522506913b420fbaecace30c15f545fb86a8cf7406179e7efa3fd'
+          - ruby: '3.3.1'
+            folder: '3.1.x' # bookworm for linux/amd64
+            tag: '3.3.1-bookworm@sha256:797d68561a91415e05fd95178f467d86d77bce2d4f17f32683241a687cbd1705'
+          - ruby: '3.4.0'
+            folder: '3.1.x' # bookworm for linux/amd64
+            tag: '3.4.0-preview1-bookworm@sha256:d0bbfb3975620c7810a7dd0da0a16dde84202fc398cface181e5a8f2c2e702bc'
     container:
       image: docker:git
       env:


### PR DESCRIPTION
Add new ruby buildpacks for building komoju.

Our applications are dependent on these buildpacks and most of them are based on these. 

This helps us pin most of our dependencies to mitigate the effect of supply chain attacks.