### PR TITLE
Add selenium/standard-chrome 4.25.0 to ECR cache

### DIFF
--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -6,6 +6,8 @@ jobs:
         include:
           - image: "selenium/standalone-chrome"
             tag: "4.7.1"
+          - image: "selenium/standalone-chrome"
+            tag: "4.25.0"
           - image: "selenium/standalone-chrome-debug"
             tag: "3.141.59"
           - image: "degicigel/echo"


### PR DESCRIPTION
This PR adds a new version of [selenium/standard-chrome](https://hub.docker.com/r/selenium/standalone-chrome) to our ECR repository.