### PR TITLE
Add selenium/standalone-chrome 4.27.0 to ECR cache

### DIFF
--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -8,6 +8,8 @@ jobs:
             tag: "4.7.1"
           - image: "selenium/standalone-chrome"
             tag: "4.25.0"
+          - image: "selenium/standalone-chrome"
+            tag: "4.27.0"
           - image: "selenium/standalone-chrome-debug"
             tag: "3.141.59"
           - image: "degicigel/echo"


### PR DESCRIPTION
We plan to upgrade selenium-standalone-chome to newer version, so this PR adds it to the list of packages to cache.