### PR TITLE
Update Rubies to 3.2.8, 3.3.7, and 3.4.2

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -5,15 +5,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.6'
+          - ruby: '3.2.8'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.2.6-slim-bookworm@sha256:c582e3505878002d0b6e316d14a4543d276c84ba040afc73fceef25b6321f80f'
-          - ruby: '3.3.6'
+            tag: '3.2.8-slim-bookworm@sha256:640d59b33ba375a288988f6503e869b9c7a8eea7b890e57b11af00599dbee917'
+          - ruby: '3.3.7'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.3.6-slim-bookworm@sha256:655ed7e1f547cfe051ec391e5b55a8cb5a1450f56903af9410dd31a6aedc5681'
-          - ruby: '3.4.1'
+            tag: '3.3.7-slim-bookworm@sha256:8b10c017ef1db7ed418d99829a91e31f12a0e3caea68022f3bb2c18f46c124f0'
+          - ruby: '3.4.2'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.1-slim-bookworm@sha256:e872e03ff02996cc9e3200bfc178c306009e851b72b9919f03d7d406ab44da94'
+            tag: '3.4.2-slim-bookworm@sha256:98e208daf93d40485edf2f5e1a1527202ae0824cdc1619b6659674a84aa197ba'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -5,15 +5,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.6'
+          - ruby: '3.2.8'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.2.6-bookworm@sha256:9f7f699c7fdd0fb44378ae80f9ac3af15908f5ae74ecb714f25ac4225453a7ea'
-          - ruby: '3.3.6'
+            tag: '3.2.8-bookworm@sha256:f69f9652f295d4c60f92ffd8f22d5afc502406b0e4ddcf84062adf2b06181a82'
+          - ruby: '3.3.7'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.3.6-bookworm@sha256:24a180b1727b169cdfab0acc2b2b70acaa1eca050e5379297eeaf7aa58e8416a'
-          - ruby: '3.4.1'
+            tag: '3.3.7-bookworm@sha256:10c28c32564e5a93b97126f60c382b55baedfdaa0c599082cf47eb97e3181149'
+          - ruby: '3.4.2'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.4.1-bookworm@sha256:45ca46a37e16d4f0b383ff6f400edc7e096361ac05c91ead86481ecc332e665e'
+            tag: '3.4.2-bookworm@sha256:dadc48c65638f936d5f113d05cb79bc09a42099b51e7744afc42cd8da4f266d8'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -16,13 +16,16 @@ rails-base contains common dependencies that our applications use. You can use `
 
 Here is a list of base images with older versions of Ruby:
 
-```ruby
+```
 public.ecr.aws/degica/rails-base:3.1.4
 public.ecr.aws/degica/rails-base:3.2.1
 public.ecr.aws/degica/rails-base:3.2.2
 public.ecr.aws/degica/rails-base:3.2.3
 public.ecr.aws/degica/rails-base:3.2.4
-public.ecr.aws/degica/rails-base:3.3.0
+public.ecr.aws/degica/rails-base:3.2.6
+public.ecr.aws/degica/rails-base:3.3.1
+public.ecr.aws/degica/rails-base:3.4.0
+public.ecr.aws/degica/rails-base:3.4.1
 ```
 
 
@@ -35,7 +38,7 @@ You can use `rails-buildpack` for your CI or builder of a multi-stage build.
 
 Here is a list of buildpacks with older versions of Ruby:
 
-```ruby
+```
 public.ecr.aws/degica/rails-buildpack:2.7
 public.ecr.aws/degica/rails-buildpack:2.7.3
 public.ecr.aws/degica/rails-buildpack:2.7.5
@@ -47,7 +50,11 @@ public.ecr.aws/degica/rails-buildpack:3.2.1
 public.ecr.aws/degica/rails-buildpack:3.2.2
 public.ecr.aws/degica/rails-buildpack:3.2.3
 public.ecr.aws/degica/rails-buildpack:3.2.4
+public.ecr.aws/degica/rails-buildpack:3.2.6
 public.ecr.aws/degica/rails-buildpack:3.3.0
+public.ecr.aws/degica/rails-buildpack:3.3.1
+public.ecr.aws/degica/rails-buildpack:3.4.0
+public.ecr.aws/degica/rails-buildpack:3.4.1
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack
@@ -55,7 +62,7 @@ Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails
 # Multi-stage example build
 
 ```
-FROM degica/rails-buildpack:2.6 AS builder
+FROM degica/rails-buildpack:3.4.2 AS builder
 
 COPY Gemfile $APP_HOME/
 COPY Gemfile.lock $APP_HOME/
@@ -70,7 +77,7 @@ ADD . $APP_HOME
 RUN bundle exec rake assets:precompile RAILS_ENV=production
 
 
-FROM degica/rails-base:2.6
+FROM degica/rails-base:3.4.2
 
 ENV APP_HOME=/app
 


### PR DESCRIPTION
This PR allows us to build our applications on latest patch version of Ruby (3.2.8, 3.3.7, and 3.4.2).