### PR TITLE
Update workflows to only build when necessary

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -1,4 +1,12 @@
 name: build-rails-base
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/build-rails-base.yml'
+      - '**/Dockerfile'
+
 jobs:
   build:
     strategy:
@@ -48,7 +56,3 @@ jobs:
         docker push $DOCKER_REPOSITORY:$IMAGE_TAG
         docker tag $DOCKER_REPOSITORY:$IMAGE_TAG $DOCKER_REPOSITORY:latest
         docker push $DOCKER_REPOSITORY:latest
-'on':
-  push:
-    branches:
-    - '*'

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -1,4 +1,11 @@
 name: build-rails-buildpack
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/build-rails-buildpack.yml'
+      - '**/Dockerfile'
 jobs:
   build:
     strategy:
@@ -48,7 +55,3 @@ jobs:
         docker push $DOCKER_REPOSITORY:$IMAGE_TAG
         docker tag $DOCKER_REPOSITORY:$IMAGE_TAG $DOCKER_REPOSITORY:latest
         docker push $DOCKER_REPOSITORY:latest
-'on':
-  push:
-    branches:
-    - '*'

--- a/.github/workflows/clone-images.yml
+++ b/.github/workflows/clone-images.yml
@@ -1,4 +1,11 @@
 name: clone-images
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/clone-images.yml'
+
 jobs:
   build:
     strategy:
@@ -49,7 +56,3 @@ jobs:
         docker tag $DOCKERHUB_IMAGE:$ORIGINAL_TAG $ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG
         docker push $ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG
         echo "$ECR_DOCKER_REPOSITORY/$NEW_IMAGE:$NEW_TAG pushed"
-'on':
-  push:
-    branches:
-    - '*'


### PR DESCRIPTION
This PR updates GitHub workflow to only build when relevant files are updated.

This is to save up on workflow cost when only, say, documentation is updated, and also avoid creating unintended update to the image.

This PR also adds `workflow_dispatch` as a trigger, so we could trigger a new image build manually via Actions page if needed.