### PR TITLE
Build Ruby 3.2.8 and 3.4.3 images

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -15,13 +15,13 @@ jobs:
         include:
           - ruby: '3.2.8'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.2.8-slim-bookworm@sha256:640d59b33ba375a288988f6503e869b9c7a8eea7b890e57b11af00599dbee917'
-          - ruby: '3.3.7'
+            tag: '3.2.8-slim-bookworm@sha256:40c82d92c01e720b81b064d826ce7b72a539eaeed01e55110106be78b4c7c5e7'
+          - ruby: '3.3.8'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.3.7-slim-bookworm@sha256:8b10c017ef1db7ed418d99829a91e31f12a0e3caea68022f3bb2c18f46c124f0'
-          - ruby: '3.4.2'
+            tag: '3.3.8-slim-bookworm@sha256:182782e8615cf731f47858a3da8f6cbf5bd60edd1d4f62bfa7cf605fc043b9b8'
+          - ruby: '3.4.3'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.2-slim-bookworm@sha256:98e208daf93d40485edf2f5e1a1527202ae0824cdc1619b6659674a84aa197ba'
+            tag: '3.4.3-slim-bookworm@sha256:fcbc3577e23cb188d769e496e7afe639b9946a2bf47c3deac7a38ad58187f6a9'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -14,13 +14,13 @@ jobs:
         include:
           - ruby: '3.2.8'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.2.8-bookworm@sha256:f69f9652f295d4c60f92ffd8f22d5afc502406b0e4ddcf84062adf2b06181a82'
-          - ruby: '3.3.7'
+            tag: '3.2.8-bookworm@sha256:c4daa0ba8880e3c77834c59bff3617cf024d96f5468b8cd897ddfa3c36560c71'
+          - ruby: '3.3.8'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.3.7-bookworm@sha256:10c28c32564e5a93b97126f60c382b55baedfdaa0c599082cf47eb97e3181149'
-          - ruby: '3.4.2'
+            tag: '3.3.8-bookworm@sha256:efddbd20dcfd2f377678292ad068583daf7a63b7b38f52db6792424f3ee43dd0'
+          - ruby: '3.4.3'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.4.2-bookworm@sha256:dadc48c65638f936d5f113d05cb79bc09a42099b51e7744afc42cd8da4f266d8'
+            tag: '3.4.3-bookworm@sha256:07c880a5e0fd72fa6cf0ff353633c488899082839578776201266e5f9fa95de0'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ public.ecr.aws/degica/rails-base:3.2.3
 public.ecr.aws/degica/rails-base:3.2.4
 public.ecr.aws/degica/rails-base:3.2.6
 public.ecr.aws/degica/rails-base:3.3.1
+public.ecr.aws/degica/rails-base:3.3.7
 public.ecr.aws/degica/rails-base:3.4.0
 public.ecr.aws/degica/rails-base:3.4.1
+public.ecr.aws/degica/rails-base:3.4.2
 ```
 
 
@@ -51,10 +53,12 @@ public.ecr.aws/degica/rails-buildpack:3.2.2
 public.ecr.aws/degica/rails-buildpack:3.2.3
 public.ecr.aws/degica/rails-buildpack:3.2.4
 public.ecr.aws/degica/rails-buildpack:3.2.6
+public.ecr.aws/degica/rails-buildpack:3.2.8
 public.ecr.aws/degica/rails-buildpack:3.3.0
 public.ecr.aws/degica/rails-buildpack:3.3.1
 public.ecr.aws/degica/rails-buildpack:3.4.0
 public.ecr.aws/degica/rails-buildpack:3.4.1
+public.ecr.aws/degica/rails-buildpack:3.4.2
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
This PR is a maintenance PR to add Ruby 3.3.8 and 3.4.3 images, as they just released recently.