### PR TITLE
Add `apt upgrade` to apply security patch to installed libs

### DIFF
--- a/rails-buildpack/3.x/Dockerfile
+++ b/rails-buildpack/3.x/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
       gstreamer1.0-tools \
       gstreamer1.0-x \
       imagemagick \
+ && apt-get upgrade -y \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Node JS


### PR DESCRIPTION
## Changes
Upgrade all library versions to latest to fix vulnerabilities.


## Context
`apt update` and `apt install` doesn't update the installed libs, so if the base image has a library with vulnerability, we are using that version in Production.

## Ticket
https://degica.atlassian.net/browse/SR-1034

## Test
* Image build worked
* The review app is also working at https://sec-update.review.staging.komoju-dev.com/en/sign_in

Before this change
<img width="1509" alt="Screenshot 2025-05-21 at 16 21 56" src="https://github.com/user-attachments/assets/ad1ea7f3-fd03-474c-b107-897e20aca3d0" />

After this change
<img width="1509" alt="Screenshot 2025-05-21 at 16 21 31" src="https://github.com/user-attachments/assets/50f72182-b47c-4ef6-b1c6-1d7ecf7deb99" />

But we have only 2 critical CVEs in Production for some reason, so not sure if this can really fix the CVEs in Prod.
<img width="1398" alt="Screenshot 2025-05-21 at 16 33 29" src="https://github.com/user-attachments/assets/7b0f4eeb-6118-4f75-bb0e-9bb61d3d7691" />

