### PR TITLE
Update Ruby 3.4 series to build 3.4.5 image

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -19,9 +19,9 @@ jobs:
           - ruby: '3.3.8'
             folder: '3.x' # slim bookworm for linux/amd64
             tag: '3.3.8-slim-bookworm@sha256:182782e8615cf731f47858a3da8f6cbf5bd60edd1d4f62bfa7cf605fc043b9b8'
-          - ruby: '3.4.3'
+          - ruby: '3.4.5'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.3-slim-bookworm@sha256:fcbc3577e23cb188d769e496e7afe639b9946a2bf47c3deac7a38ad58187f6a9'
+            tag: '3.4.5-slim-bookworm@sha256:9a1ea867b34c806f59a648fda5add63157dacf48c4f97b71fe9ad46f658b81eb'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/build-rails-buildpack.yml'
       - '**/Dockerfile'
+
 jobs:
   build:
     strategy:
@@ -18,9 +19,9 @@ jobs:
           - ruby: '3.3.8'
             folder: '3.x' # bookworm for linux/amd64
             tag: '3.3.8-bookworm@sha256:efddbd20dcfd2f377678292ad068583daf7a63b7b38f52db6792424f3ee43dd0'
-          - ruby: '3.4.3'
+          - ruby: '3.4.5'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.4.3-bookworm@sha256:07c880a5e0fd72fa6cf0ff353633c488899082839578776201266e5f9fa95de0'
+            tag: '3.4.5-bookworm@sha256:3ecd9e7112a477a44badb75fc59ca65e4d384a9d58067d520a45f8a99e568663'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ public.ecr.aws/degica/rails-base:3.3.7
 public.ecr.aws/degica/rails-base:3.4.0
 public.ecr.aws/degica/rails-base:3.4.1
 public.ecr.aws/degica/rails-base:3.4.2
+public.ecr.aws/degica/rails-base:3.4.3
 ```
 
 
@@ -59,6 +60,7 @@ public.ecr.aws/degica/rails-buildpack:3.3.1
 public.ecr.aws/degica/rails-buildpack:3.4.0
 public.ecr.aws/degica/rails-buildpack:3.4.1
 public.ecr.aws/degica/rails-buildpack:3.4.2
+public.ecr.aws/degica/rails-buildpack:3.4.3
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
Routine update: https://www.ruby-lang.org/en/news/2025/07/15/ruby-3-4-5-released/

3.4.5-bookworm: https://hub.docker.com/layers/library/ruby/3.4.5-bookworm/images/sha256-9111bdd968fd03a8ddef4e8a191fe811d496946c6c0bdf21c2ab9cc8650d127a
3.4.5-slim-bookworm: https://hub.docker.com/layers/library/ruby/3.4.5-slim-bookworm/images/sha256-a87c6f5fc16333ad3ce0b876f3f7f21dd14bd20bdd8fece955a4a502ad8eb089

This PR also adds 3.4.3 to the "list of previous version".

I guess we never build 3.4.4 😄 