### PR TITLE
Build images for 3.2.9, 3.3.10, and 3.4.8

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -21,7 +21,7 @@ jobs:
             tag: '3.3.10-slim-bookworm@sha256:66ea2735195c93ab9e33dd238c7a017afe2bcfd822b0a8d2a4d9a9b0bf61f187'
           - ruby: '3.4.8'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.5-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
+            tag: '3.4.8-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.8'
+          - ruby: '3.2.9'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.2.8-slim-bookworm@sha256:40c82d92c01e720b81b064d826ce7b72a539eaeed01e55110106be78b4c7c5e7'
-          - ruby: '3.3.8'
+            tag: '3.2.9-slim-bookworm@sha256:f1435a30f23336714d85202d368a02853545cc08f9a6005da004dc34a267d718'
+          - ruby: '3.3.10'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.3.8-slim-bookworm@sha256:182782e8615cf731f47858a3da8f6cbf5bd60edd1d4f62bfa7cf605fc043b9b8'
-          - ruby: '3.4.5'
+            tag: '3.3.10-slim-bookworm@sha256:66ea2735195c93ab9e33dd238c7a017afe2bcfd822b0a8d2a4d9a9b0bf61f187'
+          - ruby: '3.4.8'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.5-slim-bookworm@sha256:9a1ea867b34c806f59a648fda5add63157dacf48c4f97b71fe9ad46f658b81eb'
+            tag: '3.4.5-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.8'
+          - ruby: '3.2.9'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.2.8-bookworm@sha256:c4daa0ba8880e3c77834c59bff3617cf024d96f5468b8cd897ddfa3c36560c71'
-          - ruby: '3.3.8'
+            tag: '3.2.9-bookworm@sha256:2189f834a4f78b2bb1911b324fa37cb91efe41d404d22418962494506d56ea2c'
+          - ruby: '3.3.10'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.3.8-bookworm@sha256:efddbd20dcfd2f377678292ad068583daf7a63b7b38f52db6792424f3ee43dd0'
-          - ruby: '3.4.5'
+            tag: '3.3.10-bookworm@sha256:fbe24b140ddc00c3cbceb6c25220d11ce959203b543538e3fc64e185d1906da9'
+          - ruby: '3.4.8'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.4.5-bookworm@sha256:3ecd9e7112a477a44badb75fc59ca65e4d384a9d58067d520a45f8a99e568663'
+            tag: '3.4.8-bookworm@sha256:687432dc8f4094557514f9bd3cd314457d5d86008e70793b7a5d4d9beefa417f'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -17,18 +17,28 @@ rails-base contains common dependencies that our applications use. You can use `
 Here is a list of base images with older versions of Ruby:
 
 ```
+# Ruby 3.1:
 public.ecr.aws/degica/rails-base:3.1.4
+
+# Ruby 3.2:
 public.ecr.aws/degica/rails-base:3.2.1
 public.ecr.aws/degica/rails-base:3.2.2
 public.ecr.aws/degica/rails-base:3.2.3
 public.ecr.aws/degica/rails-base:3.2.4
 public.ecr.aws/degica/rails-base:3.2.6
+public.ecr.aws/degica/rails-base:3.2.8
+
+# Ruby 3.3
 public.ecr.aws/degica/rails-base:3.3.1
 public.ecr.aws/degica/rails-base:3.3.7
+public.ecr.aws/degica/rails-base:3.3.8
+
+# Ruby 3.4
 public.ecr.aws/degica/rails-base:3.4.0
 public.ecr.aws/degica/rails-base:3.4.1
 public.ecr.aws/degica/rails-base:3.4.2
 public.ecr.aws/degica/rails-base:3.4.3
+public.ecr.aws/degica/rails-base:3.4.5
 ```
 
 
@@ -42,25 +52,38 @@ You can use `rails-buildpack` for your CI or builder of a multi-stage build.
 Here is a list of buildpacks with older versions of Ruby:
 
 ```
+# Ruby 2.7
 public.ecr.aws/degica/rails-buildpack:2.7
 public.ecr.aws/degica/rails-buildpack:2.7.3
 public.ecr.aws/degica/rails-buildpack:2.7.5
 public.ecr.aws/degica/rails-buildpack:2.7.7
+
+# Ruby 3.0
 public.ecr.aws/degica/rails-buildpack:3.0
+
+# Ruby 3.1
 public.ecr.aws/degica/rails-buildpack:3.1
 public.ecr.aws/degica/rails-buildpack:3.1.4
+
+# Ruby 3.2
 public.ecr.aws/degica/rails-buildpack:3.2.1
 public.ecr.aws/degica/rails-buildpack:3.2.2
 public.ecr.aws/degica/rails-buildpack:3.2.3
 public.ecr.aws/degica/rails-buildpack:3.2.4
 public.ecr.aws/degica/rails-buildpack:3.2.6
 public.ecr.aws/degica/rails-buildpack:3.2.8
+
+# Ruby 3.3
 public.ecr.aws/degica/rails-buildpack:3.3.0
 public.ecr.aws/degica/rails-buildpack:3.3.1
+public.ecr.aws/degica/rails-buildpack:3.3.8
+
+# Ruby 3.4
 public.ecr.aws/degica/rails-buildpack:3.4.0
 public.ecr.aws/degica/rails-buildpack:3.4.1
 public.ecr.aws/degica/rails-buildpack:3.4.2
 public.ecr.aws/degica/rails-buildpack:3.4.3
+public.ecr.aws/degica/rails-buildpack:3.4.5
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
This is a routine update to add recently released version of Ruby.

- https://www.ruby-lang.org/en/news/2025/07/24/ruby-3-2-9-released/
- https://www.ruby-lang.org/en/news/2025/10/23/ruby-3-3-10-released/
- https://www.ruby-lang.org/en/news/2025/12/17/ruby-3-4-8-released/

The list of released version of Ruby can be found on https://www.ruby-lang.org/en/downloads/releases/

For `rails-buildpack`, we're using these `*-bookworm` amd64 images:
- https://hub.docker.com/layers/library/ruby/3.2.9-bookworm/images/sha256-24798ed68e173702388b161e78bb46a7290a29665ed8aa11d8005e69340cfd51
- https://hub.docker.com/layers/library/ruby/3.3.10-bookworm/images/sha256-4b39fa4a30a508b41a4629c6fbec6deafdcc511fdc8c53259319af4c2aa2698b
- https://hub.docker.com/layers/library/ruby/3.4.8-bookworm/images/sha256-53339b029598abb7421a00c46c9414abb5cf2577fe4e7584bc28b29527fcc5d7

For `rails-base`, we're using these `*-slim-bookworm` amd64 images:
- https://hub.docker.com/layers/library/ruby/3.2.9-slim-bookworm/images/sha256-08a8ffacf9f48b606fbad281c6aeb4d4cb967d84500f6e853397b96c46446213
- https://hub.docker.com/layers/library/ruby/3.3.10-slim-bookworm/images/sha256-5cf65ae398d2a94d5eb0da1a1ddf68668d77164d8060fb061ad26aa4ce362be5
- https://hub.docker.com/layers/library/ruby/3.4.8-slim-bookworm/images/sha256-3b3c4f2426c6e3498368060c0ecfebc92a09564cac833cae1be41995b28cd75c