### PR TITLE
Build docker image for Ruby 4.0.0

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -22,6 +22,9 @@ jobs:
           - ruby: '3.4.8'
             folder: '3.x' # slim bookworm for linux/amd64
             tag: '3.4.8-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
+          - ruby: '4.0.0'
+            folder: '4.x' # slim bookworm for linux/amd64
+            tag: '4.0.0-slim-bookworm@sha256:51dc3fabd6b34f3a12b54bdbe4f85e5b1800300c4c29483aecefc7eaa5430ed0'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -22,6 +22,9 @@ jobs:
           - ruby: '3.4.8'
             folder: '3.x' # bookworm for linux/amd64
             tag: '3.4.8-bookworm@sha256:687432dc8f4094557514f9bd3cd314457d5d86008e70793b7a5d4d9beefa417f'
+          - ruby: '4.0.0'
+            folder: '4.x' # bookworm for linux/amd64
+            tag: '4.0.0-bookworm@sha256:106aa117e7762e813e627f67f7a30c1fff0cc39f292a1907c3c5131f9133f483'
     container:
       image: docker:git
       env:

--- a/rails-base/4.x/Dockerfile
+++ b/rails-base/4.x/Dockerfile
@@ -1,0 +1,34 @@
+ARG RUBY_TAG=latest
+FROM public.ecr.aws/docker/library/ruby:${RUBY_TAG}
+
+ENV APP_HOME=/app
+ENV PATH=$APP_HOME/bin:$PATH
+
+RUN useradd --user-group --create-home app
+RUN mkdir -p $APP_HOME && chown -R app:app $APP_HOME
+WORKDIR $APP_HOME
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      curl \
+      file \
+      git \
+      fonts-ipafont-gothic \
+      fonts-unfonts-core \
+      imagemagick \
+      librsvg2-bin \
+      wkhtmltopdf \
+      xvfb \
+      xauth \
+      default-libmysqlclient-dev \
+      libxslt1.1 \
+      libxml2 \
+ && curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends nodejs \
+ && rm -rf /var/lib/apt/lists/*
+
+# Setup wkhtmltopdf
+RUN echo '#!/bin/bash\nxvfb-run -a --server-args="-screen 0, 1024x768x24" /usr/bin/wkhtmltopdf --enable-local-file-access -q $*' > /usr/bin/wkhtmltopdf.sh && \
+    chmod a+x /usr/bin/wkhtmltopdf.sh && \
+    ln -s /usr/bin/wkhtmltopdf.sh /usr/local/bin/wkhtmltopdf

--- a/rails-buildpack/4.x/Dockerfile
+++ b/rails-buildpack/4.x/Dockerfile
@@ -1,0 +1,46 @@
+ARG RUBY_TAG=latest
+FROM public.ecr.aws/docker/library/ruby:${RUBY_TAG}
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      file \
+      git \
+      unzip \
+      curl \
+      autoconf \
+      automake \
+      default-libmysqlclient-dev \
+      default-mysql-client \
+      g++ \
+      gcc \
+      gnupg \
+      patch \
+      make \
+      libbz2-dev \
+      libc6-dev \
+      liblzma-dev \
+      libmagickcore-dev \
+      libmagickwand-dev \
+      libreadline-dev \
+      libtool \
+      libxslt-dev \
+      libpq-dev \
+      libsqlite3-dev \
+      libxml2-dev \
+      qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
+      libqt5webkit5-dev \
+      gstreamer1.0-plugins-base \
+      gstreamer1.0-tools \
+      gstreamer1.0-x \
+      imagemagick \
+ && apt-get upgrade -y \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Node JS
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - \
+   && apt-get install -y nodejs \
+   && rm -rf /var/lib/apt/lists/*
+RUN npm install -g yarn
+
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Ruby 4.0.0 was released over the holiday: https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/

In order to be able to test our applications with Ruby 4.0.0, this PR adds Ruby 4.0.0 to the build matrix.

- https://hub.docker.com/layers/library/ruby/4.0.0-slim-bookworm/images/sha256-d1c27d3ec7c5bea91f9a3d2ca77537ca22634de8345824fe7b29d0982bcc91d4
- https://hub.docker.com/layers/library/ruby/4.0.0-bookworm/images/sha256-5acf09cc71d032e9ef661fd155c9e444f48dd1d4450ac778524b4d6aa004b653

Note that I just copied over content from `3.x` to `4.x`. 