### PR TITLE
Update Ruby 4.0.0 to Ruby 4.0.1

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.8'
             folder: '3.x' # slim bookworm for linux/amd64
             tag: '3.4.8-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
-          - ruby: '4.0.0'
+          - ruby: '4.0.1'
             folder: '4.x' # slim bookworm for linux/amd64
-            tag: '4.0.0-slim-bookworm@sha256:51dc3fabd6b34f3a12b54bdbe4f85e5b1800300c4c29483aecefc7eaa5430ed0'
+            tag: '4.0.1-slim-bookworm@sha256:9cc5aa4190d2d7be08d6a93fdd8485fb1e9ea4e7298dc4afb02118fd70d28b95'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.8'
             folder: '3.x' # bookworm for linux/amd64
             tag: '3.4.8-bookworm@sha256:687432dc8f4094557514f9bd3cd314457d5d86008e70793b7a5d4d9beefa417f'
-          - ruby: '4.0.0'
+          - ruby: '4.0.1'
             folder: '4.x' # bookworm for linux/amd64
-            tag: '4.0.0-bookworm@sha256:106aa117e7762e813e627f67f7a30c1fff0cc39f292a1907c3c5131f9133f483'
+            tag: '4.0.1-bookworm@sha256:3d214c5d400d2ec48287926193b82d90140ea508ff12f700ac1a0a78441d9e85'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ public.ecr.aws/degica/rails-base:3.4.1
 public.ecr.aws/degica/rails-base:3.4.2
 public.ecr.aws/degica/rails-base:3.4.3
 public.ecr.aws/degica/rails-base:3.4.5
+
+# Ruby 4.0
+public.ecr.aws/degica/rails-base:4.0.0
 ```
 
 
@@ -84,6 +87,9 @@ public.ecr.aws/degica/rails-buildpack:3.4.1
 public.ecr.aws/degica/rails-buildpack:3.4.2
 public.ecr.aws/degica/rails-buildpack:3.4.3
 public.ecr.aws/degica/rails-buildpack:3.4.5
+
+# Ruby 4.0
+public.ecr.aws/degica/rails-buildpack:4.0.0
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
This was released last month: https://www.ruby-lang.org/en/news/2026/01/13/ruby-4-0-1-released/

There were some important bug fixes that we probably need before able to use Ruby 4 in our projects: https://github.com/ruby/ruby/releases/tag/v4.0.1

Images from these two tags:
- https://hub.docker.com/layers/library/ruby/4.0.1-slim-bookworm/images/sha256-b3d4793a53f7b6b845b08f77f47adf33b08ede6c6f0e19baf5795fa7364daf33
- https://hub.docker.com/layers/library/ruby/4.0.1-bookworm/images/sha256-7aaadb0cc26b06d32cf675b59a6ea1a4dc3ad07b1b99b2e0984b4ebe163fd906
