### PR TITLE
Build images for Ruby 3.2.11, 3.3.11, 3.4.9, and 4.0.2

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -13,18 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.9'
+          - ruby: '3.2.11'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.2.9-slim-bookworm@sha256:f1435a30f23336714d85202d368a02853545cc08f9a6005da004dc34a267d718'
-          - ruby: '3.3.10'
+            tag: '3.2.11-slim-bookworm@sha256:1bb3b14e4cbf883f50c92bf48efdeea2126e5a2de4764c13cd7b78fb36e71052'
+          - ruby: '3.3.11'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.3.10-slim-bookworm@sha256:66ea2735195c93ab9e33dd238c7a017afe2bcfd822b0a8d2a4d9a9b0bf61f187'
-          - ruby: '3.4.8'
+            tag: '3.3.11-slim-bookworm@sha256:95f7e890438560486113d1adcf0791575f90c4e02145c6dab0bc4b6b0a2bd024'
+          - ruby: '3.4.9'
             folder: '3.x' # slim bookworm for linux/amd64
-            tag: '3.4.8-slim-bookworm@sha256:9eb304d8ca9d3eeb32a5a5a39b080b295489735510fa832ababb7ffcc079bb57'
-          - ruby: '4.0.1'
+            tag: '3.4.9-slim-bookworm@sha256:510c441d2541a5ef8c6a657a67ae98d5b0c6acdd886691690ed30f986095f55e'
+          - ruby: '4.0.2'
             folder: '4.x' # slim bookworm for linux/amd64
-            tag: '4.0.1-slim-bookworm@sha256:9cc5aa4190d2d7be08d6a93fdd8485fb1e9ea4e7298dc4afb02118fd70d28b95'
+            tag: '4.0.2-slim-bookworm@sha256:5ecc25c47ed7b9c75c24fb81fe92b474e4aae42742bca2845b69b22ee5632e2e'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -13,18 +13,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: '3.2.9'
+          - ruby: '3.2.11'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.2.9-bookworm@sha256:2189f834a4f78b2bb1911b324fa37cb91efe41d404d22418962494506d56ea2c'
-          - ruby: '3.3.10'
+            tag: '3.2.11-bookworm@sha256:d68250c0e3974511b6b8d489afb9a5e8e45aadd41dd841f6e035f7c4c03f1a54'
+          - ruby: '3.3.11'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.3.10-bookworm@sha256:fbe24b140ddc00c3cbceb6c25220d11ce959203b543538e3fc64e185d1906da9'
-          - ruby: '3.4.8'
+            tag: '3.3.11-bookworm@sha256:cdf1bbc7daaef640c62e834fa624c831b00ebb2dbf0b522e3bc43db97aa878c7'
+          - ruby: '3.4.9'
             folder: '3.x' # bookworm for linux/amd64
-            tag: '3.4.8-bookworm@sha256:687432dc8f4094557514f9bd3cd314457d5d86008e70793b7a5d4d9beefa417f'
-          - ruby: '4.0.1'
+            tag: '3.4.9-bookworm@sha256:e467a23bc24df75574b42ada7e034b38dc0e7cc52a02a911e02a75d824e0e2a6'
+          - ruby: '4.0.2'
             folder: '4.x' # bookworm for linux/amd64
-            tag: '4.0.1-bookworm@sha256:3d214c5d400d2ec48287926193b82d90140ea508ff12f700ac1a0a78441d9e85'
+            tag: '4.0.2-bookworm@sha256:3d410a7caafc13ca3eab2f973e607d2be215eb3daa199977104d9edbb6110d46'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ public.ecr.aws/degica/rails-base:3.2.3
 public.ecr.aws/degica/rails-base:3.2.4
 public.ecr.aws/degica/rails-base:3.2.6
 public.ecr.aws/degica/rails-base:3.2.8
+public.ecr.aws/degica/rails-base:3.2.9
 
 # Ruby 3.3
 public.ecr.aws/degica/rails-base:3.3.1
 public.ecr.aws/degica/rails-base:3.3.7
 public.ecr.aws/degica/rails-base:3.3.8
+public.ecr.aws/degica/rails-base:3.3.10
 
 # Ruby 3.4
 public.ecr.aws/degica/rails-base:3.4.0
@@ -39,9 +41,11 @@ public.ecr.aws/degica/rails-base:3.4.1
 public.ecr.aws/degica/rails-base:3.4.2
 public.ecr.aws/degica/rails-base:3.4.3
 public.ecr.aws/degica/rails-base:3.4.5
+public.ecr.aws/degica/rails-base:3.4.8
 
 # Ruby 4.0
 public.ecr.aws/degica/rails-base:4.0.0
+public.ecr.aws/degica/rails-base:4.0.1
 ```
 
 
@@ -75,11 +79,13 @@ public.ecr.aws/degica/rails-buildpack:3.2.3
 public.ecr.aws/degica/rails-buildpack:3.2.4
 public.ecr.aws/degica/rails-buildpack:3.2.6
 public.ecr.aws/degica/rails-buildpack:3.2.8
+public.ecr.aws/degica/rails-buildpack:3.2.9
 
 # Ruby 3.3
 public.ecr.aws/degica/rails-buildpack:3.3.0
 public.ecr.aws/degica/rails-buildpack:3.3.1
 public.ecr.aws/degica/rails-buildpack:3.3.8
+public.ecr.aws/degica/rails-buildpack:3.3.10
 
 # Ruby 3.4
 public.ecr.aws/degica/rails-buildpack:3.4.0
@@ -87,9 +93,11 @@ public.ecr.aws/degica/rails-buildpack:3.4.1
 public.ecr.aws/degica/rails-buildpack:3.4.2
 public.ecr.aws/degica/rails-buildpack:3.4.3
 public.ecr.aws/degica/rails-buildpack:3.4.5
+public.ecr.aws/degica/rails-buildpack:3.4.8
 
 # Ruby 4.0
 public.ecr.aws/degica/rails-buildpack:4.0.0
+public.ecr.aws/degica/rails-buildpack:4.0.1
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
Just a routine update to the latest versions of Rubies.

* https://hub.docker.com/layers/library/ruby/3.2.11-slim-bookworm/images/sha256-14429868053dcdfccb2457b209a5662a267280b1fbf6f82fcaca36645608b10d
* https://hub.docker.com/layers/library/ruby/3.3.11-slim-bookworm/images/sha256-ab332aa475e45750fd92900d745d8075284df183bbb930de6b7bb256bbd85e2b
* https://hub.docker.com/layers/library/ruby/3.4.9-slim-bookworm/images/sha256-0880a1f5ab2b1899569c02b1c532574858c9041f1b1bc0f3454b224e291298f2
* https://hub.docker.com/layers/library/ruby/4.0.2-slim-bookworm/images/sha256-c309928631590c935857766b2afa86093fc9b50f646c8bbe7da7de9070ce9d9c
* https://hub.docker.com/layers/library/ruby/3.2.11-bookworm/images/sha256-dce482ca68346014ca53a3407df0a1954f2606cc7942b482a71f0ac3665d15ee
* https://hub.docker.com/layers/library/ruby/3.3.11-bookworm/images/sha256-49271b643185e2ac9109c55613b89a6e68c3732a569d07a72c236777d0604550
* https://hub.docker.com/layers/library/ruby/3.4.9-bookworm/images/sha256-1f5ac08a466cad2153dab055aad13192a89d6a25dccd7770c9efe141753f5ff7
* https://hub.docker.com/layers/library/ruby/4.0.2-bookworm/images/sha256-49c1b5d34c3954ab2e3018d967d40b5561de0413d6daa12d4a25aed47761922e