### PR TITLE
Build docker image for Ruby 4.0.3

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.9'
             folder: '3.x' # slim bookworm for linux/amd64
             tag: '3.4.9-slim-bookworm@sha256:510c441d2541a5ef8c6a657a67ae98d5b0c6acdd886691690ed30f986095f55e'
-          - ruby: '4.0.2'
+          - ruby: '4.0.3'
             folder: '4.x' # slim bookworm for linux/amd64
-            tag: '4.0.2-slim-bookworm@sha256:5ecc25c47ed7b9c75c24fb81fe92b474e4aae42742bca2845b69b22ee5632e2e'
+            tag: '4.0.3-slim-bookworm@sha256:d08e29eddfcccbc48c8cb4c148fee6ad39d0cb0e20de4a0fab6dfd17221b3df5'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.9'
             folder: '3.x' # bookworm for linux/amd64
             tag: '3.4.9-bookworm@sha256:e467a23bc24df75574b42ada7e034b38dc0e7cc52a02a911e02a75d824e0e2a6'
-          - ruby: '4.0.2'
+          - ruby: '4.0.3'
             folder: '4.x' # bookworm for linux/amd64
-            tag: '4.0.2-bookworm@sha256:3d410a7caafc13ca3eab2f973e607d2be215eb3daa199977104d9edbb6110d46'
+            tag: '4.0.3-bookworm@sha256:ab0af75cd818b8b6303d3aa4c80f0cf11c6062735f71366b94acd6f091a324fa'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ public.ecr.aws/degica/rails-base:3.4.8
 # Ruby 4.0
 public.ecr.aws/degica/rails-base:4.0.0
 public.ecr.aws/degica/rails-base:4.0.1
+public.ecr.aws/degica/rails-base:4.0.2
 ```
 
 
@@ -98,6 +99,7 @@ public.ecr.aws/degica/rails-buildpack:3.4.8
 # Ruby 4.0
 public.ecr.aws/degica/rails-buildpack:4.0.0
 public.ecr.aws/degica/rails-buildpack:4.0.1
+public.ecr.aws/degica/rails-buildpack:4.0.2
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
Ruby 4.0.3 has been released: https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released/

- ruby:4.0.3-bookworm: https://hub.docker.com/layers/library/ruby/4.0.3-bookworm/images/sha256-ab0af75cd818b8b6303d3aa4c80f0cf11c6062735f71366b94acd6f091a324fa
- ruby:4.0.3-slim-bookworm: https://hub.docker.com/layers/library/ruby/4.0.3-slim-bookworm/images/sha256-d08e29eddfcccbc48c8cb4c148fee6ad39d0cb0e20de4a0fab6dfd17221b3df5