### PR TITLE
Build docker image for Ruby 4.0.4

### DIFF
--- a/.github/workflows/build-rails-base.yml
+++ b/.github/workflows/build-rails-base.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.9'
             folder: '3.x' # slim bookworm for linux/amd64
             tag: '3.4.9-slim-bookworm@sha256:510c441d2541a5ef8c6a657a67ae98d5b0c6acdd886691690ed30f986095f55e'
-          - ruby: '4.0.3'
+          - ruby: '4.0.4'
             folder: '4.x' # slim bookworm for linux/amd64
-            tag: '4.0.3-slim-bookworm@sha256:d08e29eddfcccbc48c8cb4c148fee6ad39d0cb0e20de4a0fab6dfd17221b3df5'
+            tag: '4.0.4-slim-bookworm@sha256:a9d95f9aa853c0d818f9f9b31f536adb24fb83d866e8fd1a4d3fcc5a2f229193'
     container:
       image: docker:git
       env:

--- a/.github/workflows/build-rails-buildpack.yml
+++ b/.github/workflows/build-rails-buildpack.yml
@@ -22,9 +22,9 @@ jobs:
           - ruby: '3.4.9'
             folder: '3.x' # bookworm for linux/amd64
             tag: '3.4.9-bookworm@sha256:e467a23bc24df75574b42ada7e034b38dc0e7cc52a02a911e02a75d824e0e2a6'
-          - ruby: '4.0.3'
+          - ruby: '4.0.4'
             folder: '4.x' # bookworm for linux/amd64
-            tag: '4.0.3-bookworm@sha256:ab0af75cd818b8b6303d3aa4c80f0cf11c6062735f71366b94acd6f091a324fa'
+            tag: '4.0.4-bookworm@sha256:d0447ec9bef270a7f7a0b0be3410813fd184d56cfe39775e7c7c897fb2023c5d'
     container:
       image: docker:git
       env:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ public.ecr.aws/degica/rails-base:3.4.8
 public.ecr.aws/degica/rails-base:4.0.0
 public.ecr.aws/degica/rails-base:4.0.1
 public.ecr.aws/degica/rails-base:4.0.2
+public.ecr.aws/degica/rails-base:4.0.3
 ```
 
 
@@ -100,6 +101,7 @@ public.ecr.aws/degica/rails-buildpack:3.4.8
 public.ecr.aws/degica/rails-buildpack:4.0.0
 public.ecr.aws/degica/rails-buildpack:4.0.1
 public.ecr.aws/degica/rails-buildpack:4.0.2
+public.ecr.aws/degica/rails-buildpack:4.0.3
 ```
 
 Additional older buildpacks can be found at https://gallery.ecr.aws/degica/rails-buildpack


### PR DESCRIPTION
Ruby 4.0.4 has been released: https://www.ruby-lang.org/en/news/2026/05/11/ruby-4-0-4-released/

- ruby:4.0.4-bookworm: https://hub.docker.com/layers/library/ruby/4.0.4-bookworm/images/sha256-d0447ec9bef270a7f7a0b0be3410813fd184d56cfe39775e7c7c897fb2023c5d
- ruby:4.0.4-slim-bookworm: https://hub.docker.com/layers/library/ruby/4.0.4-slim-bookworm/images/sha256-a9d95f9aa853c0d818f9f9b31f536adb24fb83d866e8fd1a4d3fcc5a2f229193